### PR TITLE
fix react error forwarding unrecognized prop by not forwarding emotion props

### DIFF
--- a/src/app/navbar/index.tsx
+++ b/src/app/navbar/index.tsx
@@ -10,7 +10,9 @@ const RootNav = styled.nav`
     align-items: center;
 `;
 
-const StyledButton = styled(Button) <{ currentPage: boolean }>`
+const StyledButton = styled(Button, {
+    shouldForwardProp: (prop) => prop !== 'currentPage'
+}) <{ currentPage: boolean }>`
     margin: 0px 3px 0px 3px;
     ${p => p.currentPage && `
         font-weight: bold;


### PR DESCRIPTION
Started getting this error:

```
Warning: React does not recognize the `currentPage` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `currentpage` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

Fixed by following this StackOverflow answer: https://stackoverflow.com/questions/71451558/getting-warning-from-props-passed-in-mui-styled-components-related-to-react-not
- add `shouldForwardProp` to emotion styled component function as option and don't forward `currentPage`.