### PR TITLE
set metadata base so that og:image does not use localhost as url

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Inter } from 'next/font/google'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata = {
+  metadataBase: new URL('https://bradchen.netlify.app'),
   title: 'Brad Chen',
   description: 'Welcome to my personal website',
 }


### PR DESCRIPTION
Was seeing og:image being set to `localhost:3000` as the base url. We need to set metadataBase to the actual hosting site name to get the correct url

![image](https://github.com/Jyntaro/personal-site/assets/26824942/37774445-a55d-421c-944f-0731e9b5d78f)